### PR TITLE
Node reverse highlight

### DIFF
--- a/relationViewer.html
+++ b/relationViewer.html
@@ -340,7 +340,7 @@ document.getElementById("is-subplace-of").addEventListener("click", subplaceOf);
 document.getElementById("has-title").addEventListener("click", hasTitle);
 
 var relationshipButtonClass = document.getElementsByClassName("relationship-button");
-for (var i = 0; i < relationshipButtonClass.length; i++) {
+for (let i = 0; i < relationshipButtonClass.length; i++) {
   relationshipButtonClass[i].addEventListener("click", setShowSameAsVisibility);
   relationshipButtonClass[i].addEventListener("click", showSameAs);
   relationshipButtonClass[i].addEventListener("click", relButtonStyle);
@@ -522,8 +522,9 @@ function loadDocument(event) {
     // console.log(displayedGraph.entities);
     // console.log(displayedGraph.relations);
     reloadDisplayedGraphToggleOn();
-    //make D3 happen
+    //make D3 simulation happen
     startSimulation();
+    enableTextToNodeHighlight();
   };
   reader.readAsText(file);
 }
@@ -649,6 +650,38 @@ function linkCut(d) {
   }
 }
 
+
+
+  // function highlightNode(id) {
+  //   d3.select("#arrayindex"+id).select("circle")
+  //     .attr("stroke", "#ff0000")
+  //     .attr("stroke-width", "4px")
+  //     .attr("r", getNodeDefaultRadius() * .7);
+  // }
+  // function textEntityClicked(entityID) {
+  //   var correspondingNode = displayedGraph.entities.find(function(entity) {
+  //     return entity.arrayindex == entityID;
+  //   });
+  //   highlightNode(correspondingNode);
+  // }
+  // textEntities refers to the tagged entities in the nbx
+function enableTextToNodeHighlight() {
+  let textEntities = document.getElementsByTagName("span");
+  for (let i = 0; i < textEntities.length; i++) {
+    textEntities[i].addEventListener("click", function(mouseEventObj) {
+      // d3.select("#arrayindex"+mouseEventObj.srcElement.id).select("circle")
+      //     .attr("stroke", "#ff0000")
+      //     .transition().attr("stroke-width", "4px")
+      //     .attr("r", getNodeDefaultRadius() * .7);
+      let entityID = mouseEventObj.srcElement.id;
+      let entity = displayedGraph.entities.find(function(e) {
+        return e.arrayindex == entityID;
+      });
+      nodeClick(entity);
+    });
+  };
+}
+
 function highlightText(d) {
   document.getElementById(d.arrayindex).style.fontWeight = "900";
   document.getElementById(d.arrayindex).style.border = "3px solid #000000";
@@ -727,29 +760,33 @@ var selectedNodeElements = [];
 function nodeClick(d) {
   // if ctrl key pressed down
   // add clicked node as relation source
-  if (d3.event.ctrlKey && getCurrentRelationship() != "UNSELECTED") {
+  if (getCurrentRelationship() != "UNSELECTED") {
+    let DOMelement = document.getElementById("arrayindex"+d.arrayindex);
     if (selectedNodes.includes(d)) {
       selectedNodes.splice(selectedNodes.indexOf(d),1);
-      d3.select(selectedNodeElements[selectedNodeElements.indexOf(this)]).select("circle")
+      d3.select(selectedNodeElements[selectedNodeElements.indexOf(DOMelement)]).select("circle")
       .transition()
       .attr('r', getNodeDefaultRadius())
       .attr("stroke", "#dfdfdf")
       .attr("stroke-width", "2px")
       .attr("fill", function(d) {return colors(d.type);});
-      selectedNodeElements.splice(selectedNodeElements.indexOf(this),1);
+      selectedNodeElements.splice(selectedNodeElements.indexOf(DOMelement),1);
+      unhighlightText(d);
       console.log("Node unselected");
     } else {
       highlightText(d);
-      d3.select(this).select("circle")
+      // console.log(this);
+      // console.log(d3.select("#arrayindex"+d.arrayindex));
+      d3.select(DOMelement).select("circle")
         .transition()
         .attr("stroke", "#ff0000")
         .attr("stroke-width", "4px")
         .attr('r', getNodeDefaultRadius() * .7);
       selectedNodes.push(d);
-      selectedNodeElements.push(this);
+      selectedNodeElements.push(DOMelement);
       console.log("Node selected");
     }
-  } else if (d3.event.ctrlKey && getCurrentRelationship() == "UNSELECTED") {
+  } else if (getCurrentRelationship() == "UNSELECTED") {
     alert("Please select a relationship type first.");
   }
 }
@@ -774,7 +811,7 @@ function clearSelection() {
   }
 }
 function onClick() {
-  if (!d3.event.ctrlKey && !hover) {
+  if (!hover) {
     // // if ctrl not pressed and click is on empty space
     // for (i in selectedNodeElements) {
     //     // console.log(selectedNodes[i]);
@@ -787,7 +824,7 @@ function onClick() {
     //   console.log("Selected nodes cleared.");
     clearSelection();
   }
-  if (!d3.event.ctrlKey && hover) {
+  if (hover) {
     console.log("hovering over a node");
   }
 }
@@ -1078,6 +1115,8 @@ function startSimulation() {
     .on("start", dragstarted)
     .on("drag", dragged)
     .on("end", dragended));
+  node.attr("id", function(d) {return "arrayindex" + d.arrayindex;})
+      .attr("arrayindex", function(d) {return d.arrayindex;});
   //draw circles for nodes
   node.append("circle")
       .attr("stroke", "#dfdfdf")
@@ -1220,6 +1259,9 @@ function restart() {
     .on("drag", dragged)
     .on("end", dragended));
   
+  enter.attr("id", function(d) {return "arrayindex" + d.arrayindex;})
+      .attr("arrayindex", function(d) {return d.arrayindex;});
+
   enter.append("circle")
       .attr("stroke", "#dfdfdf")
       .attr("stroke-width", "2px")

--- a/relationViewer.html
+++ b/relationViewer.html
@@ -634,19 +634,19 @@ function linkMouseOut(d) {
 function linkCut(d) {
   if (scissorsToggled()) {
     // console.log(d);
-    var toCutIndex = displayedGraph.relations.findIndex( function(element) {
+    let toCutIndex = displayedGraph.relations.findIndex( function(element) {
       return element == d;
     });
     console.log("Cutting at index: " + toCutIndex);
     displayedGraph.relations.splice(toCutIndex,1);
     restart();
     // now remove it from editedGraph
-    toCutIndex = editedGraph.relations.findIndex( function(element) {
-      return element == d;
-    });
+    // toCutIndex = editedGraph.relations.findIndex( function(element) {
+    //   return element == d;
+    // });
     editedGraph.relations.splice(toCutIndex,1);
-    console.log(displayedGraph);
-    console.log(editedGraph);
+    // console.log(displayedGraph);
+    // console.log(editedGraph);
   }
 }
 
@@ -678,6 +678,47 @@ function enableTextToNodeHighlight() {
         return e.arrayindex == entityID;
       });
       nodeClick(entity);
+    });
+    textEntities[i].addEventListener("dblclick", function(mouseEventObj) {
+      let entityID = mouseEventObj.srcElement.id;
+      let entity = displayedGraph.entities.find(function(e) {
+        return e.arrayindex == entityID;
+      });
+      nodeDoubleClick(entity);
+    });
+    textEntities[i].addEventListener("mouseover", function(mouseEventObj) {
+      let id = "#arrayindex" + mouseEventObj.srcElement.id;
+      // document.getElementById(id).getElementsByTagName("circle")[0]
+      d3.select(".nodes").select(id).select("circle")
+          .transition().attr("r", getNodeDefaultRadius() * 1.2)
+          .attr("stroke", "#000000")
+          .transition().attr("stroke-width","4px");
+    });
+    textEntities[i].addEventListener("mouseout", function(mouseEventObj) {
+      // if it's a selected node, we need to leave it in that state when mouseout
+      // current behavior - if I select a node, then mouseover and mouseout on other nodes,
+      // they stay big with a black border
+      // If I select a node, and hover over it, it stays black and bold.
+      // So both of these are caused by the same problem.
+      // I need to:
+      // if something is selected, it's previous state must be preserved
+      // -- selected stays small and red border
+      // -- normal goes back to normal
+      // So when mouseout-ing each node, I need to check if it is in selectedNodeElements.
+      let DOMelement = document.getElementById("arrayindex" + mouseEventObj.srcElement.id);
+      if (selectedNodeElements.includes(DOMelement)) {
+        d3.select(DOMelement).select("circle")
+        .transition()
+        .attr("stroke", "#ff0000")
+        .attr("stroke-width", "4px")
+        .attr('r', getNodeDefaultRadius() * .7);
+      } else {
+        let id = "#arrayindex" + mouseEventObj.srcElement.id;
+        d3.select(".nodes").select(id).select("circle")
+            .transition().attr("r", getNodeDefaultRadius())
+            .transition().attr("stroke-width","2px")
+            .attr("stroke", "#dfdfdf");
+      }
     });
   };
 }
@@ -727,7 +768,7 @@ function nodeDoubleClick(d) {
   console.log("Double-clicked node " + d.text);
   // console.log(selectedNodes);
   // if ctrl key not pressed and nodes are selected, make links [selected ndoes]->(clicked node)
-  if (!d3.event.ctrlKey && selectedNodes.length > 0) {
+  if (selectedNodes.length > 0) {
     for (i in selectedNodes) {
       var targetNode = d;
       displayedGraph.relations.push({type : getCurrentRelationship(),
@@ -1212,14 +1253,14 @@ function restart() {
     node
       .attr("transform", function(d) {
         return "translate("
-        + Math.max(radius, Math.min(width - 100 - radius, d.x))
+        + Math.max(radius, Math.min(width - radius, d.x))
         + ", "
         + Math.max(radius, Math.min(height - radius, d.y))
         + ")";});
     link
-      .attr("x1", function(d) {return Math.max(radius, Math.min(width - 100 - radius, d.source.x));})
+      .attr("x1", function(d) {return Math.max(radius, Math.min(width - radius, d.source.x));})
       .attr("y1", function(d) {return Math.max(radius, Math.min(height - radius, d.source.y));})
-      .attr("x2", function(d) {return Math.max(radius, Math.min(width - 100 - radius, d.target.x));})
+      .attr("x2", function(d) {return Math.max(radius, Math.min(width - radius, d.target.x));})
       .attr("y2", function(d) {return Math.max(radius, Math.min(height - radius, d.target.y));})
   }
   function dragstarted(d) {
@@ -1331,6 +1372,9 @@ function restart() {
 
   simulation.alpha(1).restart();
   console.log("Simulation restarted.");
+  if (showSameAsToggled()) {
+    sameAsRestart();
+  }
 }
 // modified restart for "same as"
 function sameAsRestart() {
@@ -1382,14 +1426,14 @@ function sameAsRestart() {
     node
       .attr("transform", function(d) {
         return "translate("
-        + Math.max(radius, Math.min(width - 100 - radius, d.x))
+        + Math.max(radius, Math.min(width - radius, d.x))
         + ", "
         + Math.max(radius, Math.min(height - radius, d.y))
         + ")";});
     link
-      .attr("x1", function(d) {return Math.max(radius, Math.min(width - 100 - radius, d.source.x));})
+      .attr("x1", function(d) {return Math.max(radius, Math.min(width - radius, d.source.x));})
       .attr("y1", function(d) {return Math.max(radius, Math.min(height - radius, d.source.y));})
-      .attr("x2", function(d) {return Math.max(radius, Math.min(width - 100 - radius, d.target.x));})
+      .attr("x2", function(d) {return Math.max(radius, Math.min(width - radius, d.target.x));})
       .attr("y2", function(d) {return Math.max(radius, Math.min(height - radius, d.target.y));});
 
     d3.select(".hull").selectAll("path")


### PR DESCRIPTION
Entity selection and relationship creation can be done in the text area. Click on a text entity to select it, double click a valid target entity to create a relationship that shows up in the displayed graph.
Mousing over text entities also highlights the corresponding node in the displayed graph.